### PR TITLE
Auto-completion, fuzzy search and better search result list 

### DIFF
--- a/Flow.Launcher.Plugin.ShortcutPlugin/Extensions/ResultExtensions.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Extensions/ResultExtensions.cs
@@ -47,7 +47,8 @@ public static class ResultExtensions
     }
 
     public static Result Result(string title, string subtitle = "", Action action = default,
-        bool hideAfterAction = true, string iconPath = default, object contextData = default)
+        bool hideAfterAction = true, string iconPath = default, object contextData = default,
+        string autoCompleteText = null)
     {
         return new Result
         {
@@ -59,7 +60,8 @@ public static class ResultExtensions
             {
                 action?.Invoke();
                 return hideAfterAction;
-            }
+            },
+            AutoCompleteText = autoCompleteText ?? title
         };
     }
 }

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Flow.Launcher.Plugin.ShortcutPlugin.csproj
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Flow.Launcher.Plugin.ShortcutPlugin.csproj
@@ -35,6 +35,7 @@
     <ItemGroup>
         <PackageReference Include="CliWrap" Version="3.6.4" />
         <PackageReference Include="Flow.Launcher.Plugin" Version="4.1.1" />
+        <PackageReference Include="FuzzySharp" Version="2.0.2" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     </ItemGroup>
 

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Services/ShortcutsService.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Services/ShortcutsService.cs
@@ -132,7 +132,10 @@ public class ShortcutsService : IShortcutsService
 
         return new List<Result>
         {
-            BuildResult(shortcut, args, $"Open {shortcut.GetDerivedType().ToLower()} shortcut",
+            BuildResult(
+                shortcut, 
+                args,
+                $"Open {shortcut.GetDerivedType().ToLower()} {shortcut.Key}",
                 shortcut.GetIcon())
         };
     }
@@ -335,7 +338,14 @@ public class ShortcutsService : IShortcutsService
             expandedShortcut, // $"{shortcut} {joinedArguments}"
             () => { _shortcutHandler.ExecuteShortcut(shortcut, arguments); },
             contextData: shortcut,
-            iconPath: iconPath
+            iconPath: iconPath,
+            autoCompleteText: shortcut switch
+                {
+                    FileShortcut fileShortcut => fileShortcut.Path,
+                    DirectoryShortcut directoryShortcut => directoryShortcut.Path,
+                    UrlShortcut urlShortcut => urlShortcut.Url,
+                    _ => null
+                }
         );
     }
 }


### PR DESCRIPTION
Change 1: Auto completion inserts value, not the key of shortcut:

https://github.com/mantasjasikenas/flow-launcher-shortcuts-plugin/assets/76812499/c99717cc-efbf-471d-8502-5a26242331ba

Change 2: Fuzzy search:


https://github.com/mantasjasikenas/flow-launcher-shortcuts-plugin/assets/76812499/d17e082d-801e-4d2f-bccf-3fb4955485c6

Change 3; Now without typing the full name of key(or auto-completing it with TAB) and then pressing ENTER, you can directly open the selected entry from the list

Change 4: changed the search result list to show relevant shortcut key, value and icon; Not just the key
