### PR TITLE
Release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ All notable changes to this project will be documented in this file.
 - When the group shortcut name (key) is not fully typed, selecting the group shortcut from the list will replace the
   query with the group shortcut name.
 - Icons folder support. If user add directory type shortcut with key `icons`, the plugin will search for icons for
-  shortcuts based on shortcut key and file name. Supported file extensions: `.png`, `.ico`, `.jpg`, `.jpeg`, `.webp`.
+  shortcuts based on shortcut key and file name. Supported file extensions: `.png`, `.jpg`, `.jpeg`, `.gif`, `.bmp`,
+  `.tiff`, `.ico`
 
 ## [1.2.0] - 2024-09-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [1.2.1] - 2024-xx-xx
+## [1.2.1] - 2024-09-24
 
 - Do not autocomplete the result when Enter is pressed if the argument is not a literal type.
-- Added a `LaunchGroup` field to group shortcuts. If set to `true`, there will be ability to launch all shortcuts in the
-  group at the same time. Otherwise, the user will be able only to launch single shortcut from the group at a time.
+- Added a `LaunchGroup` field to group shortcuts. If set to `true`, you can launch all shortcuts in the group
+  simultaneously. Otherwise, you can only launch a single shortcut from the group at a time.
 - When the group shortcut name (key) is not fully typed, selecting the group shortcut from the list will replace the
   query with the group shortcut name.
-- Icons folder support. If user add directory type shortcut with key `icons`, the plugin will search for icons for
-  shortcuts based on shortcut key and file name. Supported file extensions: `.png`, `.jpg`, `.jpeg`, `.gif`, `.bmp`,
-  `.tiff`, `.ico`
+- Icons folder support: If a directory type shortcut with the key `icons` is added, the plugin will search for icons for
+  shortcuts based on the shortcut key matching the icon file name. The icon file name should be the same as the
+  shortcut. Supported file extensions: `.png`, `.jpg`, `.jpeg`, `.ico`.
 
 ## [1.2.0] - 2024-09-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
   group at the same time. Otherwise, the user will be able only to launch single shortcut from the group at a time.
 - When the group shortcut name (key) is not fully typed, selecting the group shortcut from the list will replace the
   query with the group shortcut name.
+- Icons folder support. If user add directory type shortcut with key `icons`, the plugin will search for icons for
+  shortcuts based on shortcut key and file name. Supported file extensions: `.png`, `.ico`, `.jpg`, `.jpeg`, `.webp`.
 
 ## [1.2.0] - 2024-09-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.2.1] - 2024-xx-xx
+
+- Don't autocomplete result when pressed enter if argument is not literal type
+
 ## [1.2.0] - 2024-09-16
 
 - Fix group creation bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ## [1.2.1] - 2024-xx-xx
 
-- Don't autocomplete result when pressed enter if argument is not literal type
+- Do not autocomplete the result when Enter is pressed if the argument is not a literal type.
+- Added a `LaunchGroup` field to group shortcuts. If set to `true`, there will be ability to launch all shortcuts in the
+  group at the same time. Otherwise, the user will be able only to launch single shortcut from the group at a time.
+- When the group shortcut name (key) is not fully typed, selecting the group shortcut from the list will replace the
+  query with the group shortcut name.
 
 ## [1.2.0] - 2024-09-16
 
@@ -82,7 +86,7 @@ All notable changes to this project will be documented in this file.
   If the application is not defined, the default application will be used to open the file or URL. Example:
 
   ```json
-  {
+  [{
     "Type": "Url",
     "Url": "https://www.youtube.com/playlist?list=WL",
     "App": "msedge.exe",
@@ -99,7 +103,7 @@ All notable changes to this project will be documented in this file.
     "App": "notepad",
     "Path": "C:\\Users\\tutta\\Storage\\Motion Picture\\labas.txt",
     "Key": "t2"
-  }
+  }]
   ```
 
 ## [1.1.3] - 2024-01-31

--- a/Flow.Launcher.Plugin.ShortcutPlugin/ContextMenu.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/ContextMenu.cs
@@ -14,12 +14,12 @@ namespace Flow.Launcher.Plugin.ShortcutPlugin;
 internal class ContextMenu : IContextMenu
 {
     private readonly IVariablesService _variablesService;
-    private readonly PluginInitContext _context;
+    private readonly IPluginManager _pluginManager;
 
-    public ContextMenu(IVariablesService variablesService, PluginInitContext context)
+    public ContextMenu(IVariablesService variablesService, IPluginManager pluginManager)
     {
         _variablesService = variablesService;
-        _context = context;
+        _pluginManager = pluginManager;
     }
 
     public List<Result> LoadContextMenus(Result selectedResult)
@@ -59,7 +59,7 @@ internal class ContextMenu : IContextMenu
             contextMenu.Add(ResultExtensions.Result(
                 "Key",
                 shortcut.Key,
-                () => { _context.API.CopyToClipboard(shortcut.Key, showDefaultNotification: false); }
+                () => { _pluginManager.API.CopyToClipboard(shortcut.Key, showDefaultNotification: false); }
             ));
         }
 
@@ -70,7 +70,8 @@ internal class ContextMenu : IContextMenu
                 string.Join(", ", shortcut.Alias),
                 () =>
                 {
-                    _context.API.CopyToClipboard(string.Join(", ", shortcut.Alias), showDefaultNotification: false);
+                    _pluginManager.API.CopyToClipboard(string.Join(", ", shortcut.Alias),
+                        showDefaultNotification: false);
                 }
             ));
         }
@@ -80,7 +81,7 @@ internal class ContextMenu : IContextMenu
             contextMenu.Add(ResultExtensions.Result(
                 "Description",
                 shortcut.Description,
-                () => { _context.API.CopyToClipboard(shortcut.Description, showDefaultNotification: false); }
+                () => { _pluginManager.API.CopyToClipboard(shortcut.Description, showDefaultNotification: false); }
             ));
         }
     }
@@ -90,13 +91,16 @@ internal class ContextMenu : IContextMenu
         var copyTitle = ResultExtensions.Result(
             "Copy result title",
             selectedResult.Title,
-            action: () => { _context.API.CopyToClipboard(selectedResult.Title, showDefaultNotification: false); },
+            action: () => { _pluginManager.API.CopyToClipboard(selectedResult.Title, showDefaultNotification: false); },
             iconPath: Icons.Copy
         );
         var copySubTitle = ResultExtensions.Result(
             "Copy result subtitle",
             selectedResult.SubTitle,
-            action: () => { _context.API.CopyToClipboard(selectedResult.SubTitle, showDefaultNotification: false); },
+            action: () =>
+            {
+                _pluginManager.API.CopyToClipboard(selectedResult.SubTitle, showDefaultNotification: false);
+            },
             iconPath: Icons.Copy
         );
 
@@ -148,13 +152,13 @@ internal class ContextMenu : IContextMenu
         contextMenu.Add(ResultExtensions.Result(
             "Copy path",
             filePath,
-            action: () => { _context.API.CopyToClipboard(filePath, showDefaultNotification: false); },
+            action: () => { _pluginManager.API.CopyToClipboard(filePath, showDefaultNotification: false); },
             iconPath: Icons.Copy
         ));
 
         contextMenu.Add(ResultExtensions.Result(
             "Copy file",
-            action: () => { _context.API.CopyToClipboard(filePath, true, false); },
+            action: () => { _pluginManager.API.CopyToClipboard(filePath, true, false); },
             iconPath: Icons.Copy
         ));
 
@@ -243,7 +247,7 @@ internal class ContextMenu : IContextMenu
 
         contextMenu.Add(ResultExtensions.Result(
             "Copy path",
-            action: () => { _context.API.CopyToClipboard(directoryPath, showDefaultNotification: false); },
+            action: () => { _pluginManager.API.CopyToClipboard(directoryPath, showDefaultNotification: false); },
             iconPath: Icons.Copy
         ));
 

--- a/Flow.Launcher.Plugin.ShortcutPlugin/ContextMenu.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/ContextMenu.cs
@@ -4,9 +4,10 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Flow.Launcher.Plugin.ShortcutPlugin.Extensions;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Models.Shortcuts;
 using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
-using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin;

--- a/Flow.Launcher.Plugin.ShortcutPlugin/DI/DependencyInjection.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/DI/DependencyInjection.cs
@@ -17,6 +17,7 @@ public static class DependencyInjection
     )
     {
         services.AddSingleton(context);
+        services.AddSingleton<IPluginManager, PluginManager>();
         services.AddSingleton<ISettingsService, SettingsService>();
         services.AddSingleton<IShortcutsRepository, ShortcutsRepository>();
         services.AddSingleton<IShortcutsService, ShortcutsService>();

--- a/Flow.Launcher.Plugin.ShortcutPlugin/DI/DependencyInjection.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/DI/DependencyInjection.cs
@@ -1,9 +1,10 @@
-﻿using Flow.Launcher.Plugin.ShortcutPlugin.Models.Commands;
+﻿using Flow.Launcher.Plugin.ShortcutPlugin.Helper;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
+using Flow.Launcher.Plugin.ShortcutPlugin.Models.Commands;
 using Flow.Launcher.Plugin.ShortcutPlugin.Repositories;
 using Flow.Launcher.Plugin.ShortcutPlugin.Repositories.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Services;
 using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
-using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 using Flow.Launcher.Plugin.ShortcutPlugin.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -17,6 +18,7 @@ public static class DependencyInjection
     )
     {
         services.AddSingleton(context);
+        services.AddSingleton<IReloadable, Reloadable>();
         services.AddSingleton<IPluginManager, PluginManager>();
         services.AddSingleton<ISettingsService, SettingsService>();
         services.AddSingleton<IShortcutsRepository, ShortcutsRepository>();
@@ -29,6 +31,7 @@ public static class DependencyInjection
         services.AddSingleton<IBackupService, BackupService>();
         services.AddSingleton<ISettingProvider, ShortcutPlugin>();
         services.AddSingleton<IShortcutHandler, ShortcutHandler>();
+        services.AddSingleton<IIconProvider, IconProvider>();
         services.AddSingleton<SettingsViewModel, SettingsViewModel>();
         services.AddScoped<ContextMenu>();
 

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Extensions/ResultExtensions.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Extensions/ResultExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Extensions;
 

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Extensions/ResultExtensions.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Extensions/ResultExtensions.cs
@@ -8,7 +8,7 @@ public static class ResultExtensions
 {
     public static List<Result> ToList(this Result result)
     {
-        return new List<Result> {result};
+        return [result];
     }
 
     public static List<Result> EmptyResult()
@@ -31,9 +31,9 @@ public static class ResultExtensions
         IList<int> titleHighlightData = default
     )
     {
-        return new List<Result>
-        {
-            new()
+        return
+        [
+            new Result
             {
                 Title = title,
                 SubTitle = subtitle,
@@ -46,7 +46,7 @@ public static class ResultExtensions
                     return hideAfterAction;
                 }
             }
-        };
+        ];
     }
 
     public static Result Result(

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Helper/AppUtilities.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Helper/AppUtilities.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using Microsoft.Win32;
 
-namespace Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
+namespace Flow.Launcher.Plugin.ShortcutPlugin.Helper;
 
 public static class AppUtilities
 {

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Constants.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Constants.cs
@@ -1,4 +1,6 @@
-﻿namespace Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
+﻿using System.Collections.Generic;
+
+namespace Flow.Launcher.Plugin.ShortcutPlugin.Helper;
 
 public static class Constants
 {
@@ -22,4 +24,13 @@ public static class Constants
     public const string ReadmeUrl = GithubRepository + "/blob/master/README.md";
 
     public const string DiscordUsername = "mantelis130";
+
+    public static readonly List<string> IconsExtensions =
+    [
+        ".ico",
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".webp"
+    ];
 }

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Constants.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Constants.cs
@@ -27,10 +27,6 @@ public static class Constants
 
     public static readonly List<string> IconsExtensions =
     [
-        ".ico",
-        ".png",
-        ".jpg",
-        ".jpeg",
-        ".webp"
+        ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".ico"
     ];
 }

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Helper/IconProvider.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Helper/IconProvider.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
+using Flow.Launcher.Plugin.ShortcutPlugin.Models.Shortcuts;
+using Flow.Launcher.Plugin.ShortcutPlugin.Repositories.Interfaces;
+using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
+
+namespace Flow.Launcher.Plugin.ShortcutPlugin.Helper;
+
+public class IconProvider : IIconProvider
+{
+    private readonly IShortcutsRepository _shortcutsRepository;
+    private readonly IVariablesService _variablesService;
+
+    private readonly Dictionary<string, string> _arguments = new();
+
+    private readonly Dictionary<string, List<string>> _directoryCache = new();
+    private readonly TimeSpan _cacheDuration = TimeSpan.FromMinutes(10);
+    private DateTime _lastCacheUpdate = DateTime.MinValue;
+
+    public IconProvider(IShortcutsRepository shortcutsRepository,
+        IVariablesService variablesService
+    )
+    {
+        _shortcutsRepository = shortcutsRepository;
+        _variablesService = variablesService;
+    }
+
+    public string GetIcon(Shortcut shortcut)
+    {
+        if (!string.IsNullOrEmpty(shortcut.Icon))
+        {
+            if (Path.Exists(shortcut.Icon))
+            {
+                return shortcut.Icon;
+            }
+
+            if (TryGetIconFromIcons(out var icon, shortcut.Icon))
+            {
+                return icon;
+            }
+        }
+
+        if (TryGetIconFromIcons(out var iconBasedOnKey, shortcut.Key))
+        {
+            return iconBasedOnKey;
+        }
+
+        return shortcut switch
+        {
+            FileShortcut fileShortcut => GetFileShortcutIcon(fileShortcut),
+            DirectoryShortcut directoryShortcut => GetDirectoryShortcutIcon(directoryShortcut),
+            UrlShortcut urlShortcut => GetUrlShortcutIcon(urlShortcut),
+            ShellShortcut shellShortcut => GetShellShortcutIcon(shellShortcut),
+            GroupShortcut => Icons.TabGroup,
+            _ => Icons.Logo
+        };
+    }
+
+    public void Reload()
+    {
+        _directoryCache.Clear();
+        _lastCacheUpdate = DateTime.MinValue;
+    }
+
+    private string GetShellShortcutIcon(ShellShortcut shellShortcut)
+    {
+        return shellShortcut.ShellType switch
+        {
+            ShellType.Cmd => Icons.WindowsTerminal,
+            ShellType.Powershell => Icons.PowerShellBlack,
+            _ => Icons.Terminal
+        };
+    }
+
+    private string GetUrlShortcutIcon(UrlShortcut urlShortcut)
+    {
+        if (!(urlShortcut.Url.Contains("www.") || urlShortcut.Url.Contains("http") ||
+              urlShortcut.Url.Contains("https")))
+        {
+            return AppUtilities.GetApplicationPath(urlShortcut.Url.Split(':')[0]);
+        }
+
+        if (string.IsNullOrEmpty(urlShortcut.App))
+        {
+            return AppUtilities.GetSystemDefaultBrowser();
+        }
+
+        if (Path.Exists(urlShortcut.App))
+        {
+            return urlShortcut.App;
+        }
+
+        var path = AppUtilities.GetApplicationPath(urlShortcut.App);
+
+        return !string.IsNullOrEmpty(path) ? path : Icons.Link;
+    }
+
+    private string GetDirectoryShortcutIcon(DirectoryShortcut directoryShortcut)
+    {
+        return _variablesService.ExpandVariables(directoryShortcut.Path, _arguments);
+    }
+
+    private string GetFileShortcutIcon(FileShortcut fileShortcut)
+    {
+        var path = _variablesService.ExpandVariables(fileShortcut.Path, _arguments);
+
+        return string.IsNullOrEmpty(fileShortcut.App)
+            ? path
+            : AppUtilities.GetApplicationPath(fileShortcut.App);
+    }
+
+    private bool TryGetIconFromIcons(out string icon, string key)
+    {
+        var shortcuts = _shortcutsRepository.GetShortcuts("icons");
+        icon = null;
+
+        if (shortcuts is null || shortcuts is {Count: < 1} ||
+            shortcuts.First() is not DirectoryShortcut directoryShortcut || !Directory.Exists(directoryShortcut.Path))
+        {
+            return false;
+        }
+
+        var files = GetCachedFiles(directoryShortcut.Path);
+
+        icon = files.FirstOrDefault(file =>
+            Path.GetFileNameWithoutExtension(file)
+                .Equals(key, StringComparison.OrdinalIgnoreCase) &&
+            Constants.IconsExtensions.Contains(Path.GetExtension(file))
+        );
+
+        return icon != null;
+    }
+
+    private List<string> GetCachedFiles(string directoryPath)
+    {
+        if (_directoryCache.TryGetValue(directoryPath, out var cachedFiles) &&
+            DateTime.Now - _lastCacheUpdate < _cacheDuration)
+        {
+            return cachedFiles;
+        }
+
+        var files = Directory.GetFiles(directoryPath).ToList();
+
+        _directoryCache[directoryPath] = files;
+        _lastCacheUpdate = DateTime.Now;
+
+        return files;
+    }
+}

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Helper/IconProvider.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Helper/IconProvider.cs
@@ -43,7 +43,8 @@ public class IconProvider : IIconProvider
     {
         if (!string.IsNullOrEmpty(shortcut.Icon))
         {
-            if (Path.Exists(shortcut.Icon))
+            if (Path.Exists(shortcut.Icon) || shortcut.Icon.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+                shortcut.Icon.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
             {
                 return shortcut.Icon;
             }

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Icons.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Icons.cs
@@ -1,4 +1,4 @@
-﻿namespace Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
+﻿namespace Flow.Launcher.Plugin.ShortcutPlugin.Helper;
 
 public static class Icons
 {

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Interfaces/IAsyncInitializable.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Interfaces/IAsyncInitializable.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+
+namespace Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
+
+public interface IAsyncInitializable
+{
+    Task InitializeAsync();
+}

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Interfaces/IIconProvider.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Interfaces/IIconProvider.cs
@@ -2,7 +2,7 @@ using Flow.Launcher.Plugin.ShortcutPlugin.Models.Shortcuts;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 
-public interface IIconProvider
+public interface IIconProvider : IAsyncInitializable
 {
     string GetIcon(Shortcut shortcut);
     void Reload();

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Interfaces/IIconProvider.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Interfaces/IIconProvider.cs
@@ -1,0 +1,9 @@
+using Flow.Launcher.Plugin.ShortcutPlugin.Models.Shortcuts;
+
+namespace Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
+
+public interface IIconProvider
+{
+    string GetIcon(Shortcut shortcut);
+    void Reload();
+}

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Interfaces/IPluginManager.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Interfaces/IPluginManager.cs
@@ -1,4 +1,4 @@
-namespace Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
+namespace Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 
 public interface IPluginManager
 {
@@ -29,9 +29,20 @@ public interface IPluginManager
     void SetLastQuery(Query query);
 
     /// <summary>
+    /// Used to set the reloadable object (cannot inject it in the constructor because of circular dependency)
+    /// </summary>
+    /// <param name="reloadable"></param>
+    void SetReloadable(IReloadable reloadable);
+
+    /// <summary>
     /// Clear the last query
     /// </summary>
     void ClearLastQuery();
+
+    /// <summary>
+    /// Reload the data of the plugin
+    /// </summary>
+    void ReloadPluginData();
 
     /// <summary>
     /// Get the action keyword from the last query or the first action keyword from the plugin metadata

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Interfaces/IShortcutHandler.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Interfaces/IShortcutHandler.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using Flow.Launcher.Plugin.ShortcutPlugin.Models.Shortcuts;
 
-namespace Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
+namespace Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 
 public interface IShortcutHandler
 {

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Helper/PluginManager.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Helper/PluginManager.cs
@@ -1,4 +1,6 @@
-namespace Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
+
+namespace Flow.Launcher.Plugin.ShortcutPlugin.Helper;
 
 public class PluginManager : IPluginManager
 {
@@ -11,10 +13,20 @@ public class PluginManager : IPluginManager
     public Query LastQuery { get; private set; }
 
 
-    public PluginManager(PluginInitContext context)
+    private IReloadable _reloadable;
+
+
+    public PluginManager(
+        PluginInitContext context
+    )
     {
         Context = context;
         LastQuery = new Query();
+    }
+
+    public void SetReloadable(IReloadable reloadable)
+    {
+        _reloadable = reloadable;
     }
 
     public void SetLastQuery(Query query)
@@ -26,6 +38,13 @@ public class PluginManager : IPluginManager
     {
         LastQuery = new Query();
     }
+
+    public void ReloadPluginData()
+    {
+        ClearLastQuery();
+        _reloadable.ReloadData();
+    }
+
 
     public string GetActionKeyword()
     {

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Helper/PluginManager.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Helper/PluginManager.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Helper;
@@ -16,9 +17,7 @@ public class PluginManager : IPluginManager
     private IReloadable _reloadable;
 
 
-    public PluginManager(
-        PluginInitContext context
-    )
+    public PluginManager(PluginInitContext context)
     {
         Context = context;
         LastQuery = new Query();

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Helper/QueryBuilder.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Helper/QueryBuilder.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 
-namespace Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
+namespace Flow.Launcher.Plugin.ShortcutPlugin.Helper;
 
 public static class QueryBuilder
 {

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Reloadable.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Reloadable.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
 
@@ -24,8 +25,15 @@ public class Reloadable : IReloadable
     public void ReloadData()
     {
         _settingsService.Reload();
-        _shortcutsService.Reload();
-        _variablesService.Reload();
+
+        var reloadTasks = new[]
+        {
+            Task.Run(() => _variablesService.Reload()),
+            Task.Run(() => _shortcutsService.Reload())
+        };
+
+        Task.WhenAll(reloadTasks).GetAwaiter().GetResult();
+
         _iconProvider.Reload();
     }
 }

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Reloadable.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Helper/Reloadable.cs
@@ -1,0 +1,31 @@
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
+using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
+
+namespace Flow.Launcher.Plugin.ShortcutPlugin.Helper;
+
+public class Reloadable : IReloadable
+{
+    private readonly ISettingsService _settingsService;
+    private readonly IShortcutsService _shortcutsService;
+    private readonly IVariablesService _variablesService;
+    private readonly IIconProvider _iconProvider;
+
+    public Reloadable(IVariablesService variablesService,
+        IShortcutsService shortcutsService, ISettingsService settingsService,
+        IIconProvider iconProvider
+    )
+    {
+        _variablesService = variablesService;
+        _shortcutsService = shortcutsService;
+        _settingsService = settingsService;
+        _iconProvider = iconProvider;
+    }
+
+    public void ReloadData()
+    {
+        _settingsService.Reload();
+        _shortcutsService.Reload();
+        _variablesService.Reload();
+        _iconProvider.Reload();
+    }
+}

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Helper/ShortcutHandler.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Helper/ShortcutHandler.cs
@@ -3,11 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Flow.Launcher.Plugin.ShortcutPlugin.Extensions;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Models.Shortcuts;
 using Flow.Launcher.Plugin.ShortcutPlugin.Repositories.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
 
-namespace Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
+namespace Flow.Launcher.Plugin.ShortcutPlugin.Helper;
 
 public class ShortcutHandler : IShortcutHandler
 {

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Helper/ShortcutUtilities.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Helper/ShortcutUtilities.cs
@@ -1,7 +1,7 @@
 ﻿using System.Diagnostics;
 using CliWrap;
 
-namespace Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
+namespace Flow.Launcher.Plugin.ShortcutPlugin.Helper;
 
 public static class ShortcutUtilities
 {

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Models/Command.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Models/Command.cs
@@ -3,18 +3,11 @@ using System.Collections.Generic;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.models;
 
-public class Command : BaseQueryExecutor
-{
-}
+public class Command : BaseQueryExecutor;
 
-public class Argument : BaseQueryExecutor
-{
-}
+public class Argument : BaseQueryExecutor;
 
-public class ArgumentLiteral : Argument
-{
-}
-
+public class ArgumentLiteral : Argument;
 
 public class BaseQueryExecutor : IQueryExecutor
 {

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Models/CommandBuilder.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Models/CommandBuilder.cs
@@ -4,17 +4,11 @@ using Flow.Launcher.Plugin.ShortcutPlugin.models;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Models;
 
-public class CommandBuilder : BaseQueryBuilder<Command>
-{
-}
+public class CommandBuilder : BaseQueryBuilder<Command>;
 
-public class ArgumentBuilder : BaseQueryBuilder<Argument>
-{
-}
+public class ArgumentBuilder : BaseQueryBuilder<Argument>;
 
-public class ArgumentLiteralBuilder : BaseQueryBuilder<ArgumentLiteral>
-{
-}
+public class ArgumentLiteralBuilder : BaseQueryBuilder<ArgumentLiteral>;
 
 public abstract class BaseQueryBuilder<T> where T : BaseQueryExecutor, new()
 {
@@ -58,7 +52,7 @@ public abstract class BaseQueryBuilder<T> where T : BaseQueryExecutor, new()
 
     public BaseQueryBuilder<T> WithArgument(IQueryExecutor argument)
     {
-        _instance.Arguments ??= new List<IQueryExecutor>();
+        _instance.Arguments ??= [];
         _instance.Arguments.Add(argument);
 
         return this;
@@ -66,7 +60,7 @@ public abstract class BaseQueryBuilder<T> where T : BaseQueryExecutor, new()
 
     public BaseQueryBuilder<T> WithArguments(IEnumerable<IQueryExecutor> arguments)
     {
-        _instance.Arguments ??= new List<IQueryExecutor>();
+        _instance.Arguments ??= [];
         _instance.Arguments.AddRange(arguments);
 
         return this;
@@ -74,7 +68,7 @@ public abstract class BaseQueryBuilder<T> where T : BaseQueryExecutor, new()
 
     public BaseQueryBuilder<T> WithArguments(params IQueryExecutor[] arguments)
     {
-        _instance.Arguments ??= new List<IQueryExecutor>();
+        _instance.Arguments ??= [];
         _instance.Arguments.AddRange(arguments);
 
         return this;

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/GroupCommand.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/GroupCommand.cs
@@ -40,7 +40,8 @@ public class GroupCommand : ICommand
     private ArgumentLiteral CreateAddSubCommand()
     {
         var addGroupKeysArgument = CreateAddGroupKeysArgument();
-        var addGroupNameArgument = CreateAddGroupNameArgument(addGroupKeysArgument);
+        var addGroupGroupLaunchArgument = CreateAddGroupGroupLaunchArgument(addGroupKeysArgument);
+        var addGroupNameArgument = CreateAddGroupNameArgument(addGroupGroupLaunchArgument);
 
         return new ArgumentLiteralBuilder()
                .WithKey("add")
@@ -63,7 +64,14 @@ public class GroupCommand : ICommand
     {
         return new ArgumentBuilder()
                .WithResponseInfo(("Enter group name", "How should your group be named?"))
-               .WithResponseSuccess(("Add", "Your group will be added"))
+               .WithArguments(addGroupKeysArgument)
+               .Build();
+    }
+
+    private Argument CreateAddGroupGroupLaunchArgument(IQueryExecutor addGroupKeysArgument)
+    {
+        return new ArgumentBuilder()
+               .WithResponseInfo(("Enable group launch", "Should the group be launched as a group? (true/false)"))
                .WithArguments(addGroupKeysArgument)
                .Build();
     }
@@ -107,12 +115,12 @@ public class GroupCommand : ICommand
 
     private List<Result> AddGroupCommandHandler(ActionContext context, List<string> arguments)
     {
-        var keys = arguments.Skip(3).ToList();
+        var launchGroup = !bool.TryParse(arguments[3], out var groupLaunch) || groupLaunch;
+        var keys = arguments.Skip(4).ToList();
+        var key = arguments[2];
 
-        return ResultExtensions.SingleResult("Creating group shortcut", "Keys : " + string.Join(", ", keys), () =>
-        {
-            var key = arguments[2];
-            _shortcutsRepository.GroupShortcuts(key, keys);
-        });
+        return ResultExtensions.SingleResult("Creating group shortcut",
+            $"Group launch : {launchGroup.ToString().ToLowerInvariant()}, keys : {string.Join(", ", keys)}",
+            () => { _shortcutsRepository.GroupShortcuts(key, launchGroup, keys); });
     }
 }

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/HelpCommand.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/HelpCommand.cs
@@ -1,7 +1,8 @@
 using System.Collections.Generic;
 using Flow.Launcher.Plugin.ShortcutPlugin.Extensions;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.models;
-using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Models.Commands;
 

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/HelpCommand.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/HelpCommand.cs
@@ -7,11 +7,11 @@ namespace Flow.Launcher.Plugin.ShortcutPlugin.Models.Commands;
 
 public class HelpCommand : ICommand
 {
-    private readonly PluginInitContext _context;
+    private readonly IPluginManager _pluginManager;
 
-    public HelpCommand(PluginInitContext context)
+    public HelpCommand(IPluginManager pluginManager)
     {
-        _context = context;
+        _pluginManager = pluginManager;
     }
 
     public Command Create()
@@ -50,7 +50,7 @@ public class HelpCommand : ICommand
         var discordResult = ResultExtensions.Result(
             "Contact the developer on Discord",
             "Username: " + Constants.DiscordUsername,
-            () => { _context.API.CopyToClipboard(Constants.DiscordUsername); },
+            () => { _pluginManager.API.CopyToClipboard(Constants.DiscordUsername); },
             iconPath: Icons.Discord,
             autoCompleteText: Constants.DiscordUsername
         );

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/KeywordCommand.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/KeywordCommand.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Flow.Launcher.Plugin.ShortcutPlugin.Extensions;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.models;
-using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Models.Commands;
 

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/ReloadCommand.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/ReloadCommand.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Flow.Launcher.Plugin.ShortcutPlugin.Extensions;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.models;
 using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
 
@@ -7,16 +8,11 @@ namespace Flow.Launcher.Plugin.ShortcutPlugin.Models.Commands;
 
 public class ReloadCommand : ICommand
 {
-    private readonly IShortcutsService _shortcutsService;
-    private readonly ISettingsService _settingsService;
-    private readonly IVariablesService _variablesService;
+    private readonly IPluginManager _pluginManager;
 
-    public ReloadCommand(IShortcutsService shortcutsService, ISettingsService settingsService,
-        IVariablesService variablesService)
+    public ReloadCommand(IPluginManager pluginManager)
     {
-        _shortcutsService = shortcutsService;
-        _settingsService = settingsService;
-        _variablesService = variablesService;
+        _pluginManager = pluginManager;
     }
 
     public Command Create()
@@ -37,11 +33,7 @@ public class ReloadCommand : ICommand
 
     private List<Result> ReloadCommandHandler(ActionContext context, List<string> arguments)
     {
-        return ResultExtensions.SingleResult("Reload plugin data", "This action will reload all plugin data", () =>
-        {
-            _settingsService.Reload();
-            _shortcutsService.Reload();
-            _variablesService.Reload();
-        });
+        return ResultExtensions.SingleResult("Reload plugin data", "This action will reload all plugin data",
+            () => { _pluginManager.ReloadPluginData(); });
     }
 }

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/ReportCommand.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/ReportCommand.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Flow.Launcher.Plugin.ShortcutPlugin.Extensions;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper;
 using Flow.Launcher.Plugin.ShortcutPlugin.models;
-using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Models.Commands;
 

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/SettingsCommand.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/SettingsCommand.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Flow.Launcher.Plugin.ShortcutPlugin.Extensions;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.models;
-using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Models.Commands;
 

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/SettingsCommand.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/SettingsCommand.cs
@@ -1,16 +1,17 @@
 using System.Collections.Generic;
 using Flow.Launcher.Plugin.ShortcutPlugin.Extensions;
 using Flow.Launcher.Plugin.ShortcutPlugin.models;
+using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Models.Commands;
 
 public class SettingsCommand : ICommand
 {
-    private readonly PluginInitContext _context;
+    private readonly IPluginManager _pluginManager;
 
-    public SettingsCommand(PluginInitContext context)
+    public SettingsCommand(IPluginManager pluginManager)
     {
-        _context = context;
+        _pluginManager = pluginManager;
     }
 
     public Command Create()
@@ -21,16 +22,16 @@ public class SettingsCommand : ICommand
     private Command CreateSettingsCommand()
     {
         return new CommandBuilder()
-            .WithKey("settings")
-            .WithResponseInfo(("settings", "Open settings"))
-            .WithResponseFailure(("Failed to open settings", "Something went wrong"))
-            .WithHandler(SettingsCommandHandler)
-            .Build();
+               .WithKey("settings")
+               .WithResponseInfo(("settings", "Open settings"))
+               .WithResponseFailure(("Failed to open settings", "Something went wrong"))
+               .WithHandler(SettingsCommandHandler)
+               .Build();
     }
 
     private List<Result> SettingsCommandHandler(ActionContext context, List<string> arguments)
     {
         return ResultExtensions.SingleResult("Open Flow Launcher settings", "",
-            _context.API.OpenSettingDialog);
+            _pluginManager.API.OpenSettingDialog);
     }
 }

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/VersionCommand.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/VersionCommand.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using Flow.Launcher.Plugin.ShortcutPlugin.Extensions;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.models;
-using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Models.Commands;
 

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/VersionCommand.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Models/Commands/VersionCommand.cs
@@ -1,16 +1,17 @@
 ﻿using System.Collections.Generic;
 using Flow.Launcher.Plugin.ShortcutPlugin.Extensions;
 using Flow.Launcher.Plugin.ShortcutPlugin.models;
+using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Models.Commands;
 
 public class VersionCommand : ICommand
 {
-    private readonly PluginInitContext _context;
+    private readonly IPluginManager _pluginManager;
 
-    public VersionCommand(PluginInitContext context)
+    public VersionCommand(IPluginManager pluginManager)
     {
-        _context = context;
+        _pluginManager = pluginManager;
     }
 
     public Command Create()
@@ -31,7 +32,7 @@ public class VersionCommand : ICommand
 
     private List<Result> VersionCommandHandler(ActionContext context, List<string> arguments)
     {
-        var version = _context.CurrentPluginMetadata.Version;
+        var version = _pluginManager.Context.CurrentPluginMetadata.Version;
 
         return ResultExtensions.SingleResult("Plugin version", version);
     }

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Models/Shortcuts/GroupShortcut.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Models/Shortcuts/GroupShortcut.cs
@@ -10,6 +10,8 @@ public class GroupShortcut : Shortcut
 
     public List<string>? Keys { get; init; }
 
+    public bool GroupLaunch { get; init; } = true;
+
     public override object Clone()
     {
         return new GroupShortcut

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Models/Shortcuts/ShortcutType.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Models/Shortcuts/ShortcutType.cs
@@ -5,8 +5,6 @@ public enum ShortcutType
     Directory,
     File,
     Url,
-    Plugin,
     Group,
-    Unspecified,
     Shell
 }

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/BackupRepository.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/BackupRepository.cs
@@ -2,10 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Models;
 using Flow.Launcher.Plugin.ShortcutPlugin.Repositories.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
-using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Repositories;
 

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/BackupRepository.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/BackupRepository.cs
@@ -11,7 +11,7 @@ namespace Flow.Launcher.Plugin.ShortcutPlugin.Repositories;
 
 public class BackupRepository : IBackupRepository
 {
-    private readonly PluginInitContext _context;
+    private readonly IPluginManager _pluginManager;
 
     private readonly ISettingsService _settingsService;
 
@@ -21,10 +21,10 @@ public class BackupRepository : IBackupRepository
 
     private string BackupPath => GetBackupPath();
 
-    public BackupRepository(PluginInitContext context, ISettingsService settingsService,
+    public BackupRepository(IPluginManager pluginManager, ISettingsService settingsService,
         IShortcutsRepository shortcutsRepository, IVariablesRepository variablesRepository)
     {
-        _context = context;
+        _pluginManager = pluginManager;
         _settingsService = settingsService;
         _shortcutsRepository = shortcutsRepository;
         _variablesRepository = variablesRepository;
@@ -42,7 +42,7 @@ public class BackupRepository : IBackupRepository
 
     private string GetBackupPath()
     {
-        var pluginDirectory = _context.CurrentPluginMetadata.PluginDirectory;
+        var pluginDirectory = _pluginManager.Metadata.PluginDirectory;
         var parentDirectory = Directory.GetParent(pluginDirectory)?.Parent?.FullName;
 
         if (parentDirectory == null)

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/CommandsRepository.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/CommandsRepository.cs
@@ -2,11 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using Flow.Launcher.Plugin.ShortcutPlugin.Extensions;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.models;
 using Flow.Launcher.Plugin.ShortcutPlugin.Models.Commands;
 using Flow.Launcher.Plugin.ShortcutPlugin.Repositories.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
-using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Repositories;
 

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/CommandsRepository.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/CommandsRepository.cs
@@ -6,7 +6,6 @@ using Flow.Launcher.Plugin.ShortcutPlugin.models;
 using Flow.Launcher.Plugin.ShortcutPlugin.Models.Commands;
 using Flow.Launcher.Plugin.ShortcutPlugin.Repositories.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
-using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Repositories;
 
@@ -105,13 +104,21 @@ public class CommandsRepository : ICommandsRepository
 
             return executor
                    .Arguments.Cast<Argument>()
-                   .Select(a =>
+                   .Select(argument =>
                        ResultExtensions.Result(
-                           title: a.ResponseInfo.Item1,
-                           subtitle: a.ResponseInfo.Item2,
-                           () => { _context.API.ChangeQuery($"{query.ActionKeyword} {a.ResponseInfo.Item1}"); },
+                           title: argument.ResponseInfo.Item1,
+                           subtitle: argument.ResponseInfo.Item2,
+                           () =>
+                           {
+                               if (argument is ArgumentLiteral)
+                               {
+                                   _context.API.ChangeQuery($"{query.ActionKeyword} {argument.ResponseInfo.Item1}");
+                               }
+                           },
                            hideAfterAction: false,
-                           autoCompleteText: $"{query.ActionKeyword} {a.ResponseInfo.Item1}"
+                           autoCompleteText: argument is ArgumentLiteral
+                               ? $"{query.ActionKeyword} {argument.ResponseInfo.Item1}"
+                               : $"{query.RawQuery}"
                        )
                    )
                    .ToList();

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/Interfaces/IShortcutsRepository.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/Interfaces/IShortcutsRepository.cs
@@ -17,5 +17,5 @@ public interface IShortcutsRepository
     void ImportShortcuts(string path);
     void ExportShortcuts(string path);
     IList<GroupShortcut> GetGroups();
-    void GroupShortcuts(string groupKey, IEnumerable<string> shortcutKeys);
+    void GroupShortcuts(string groupKey, bool groupLaunch, IEnumerable<string> shortcutKeys);
 }

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/Interfaces/IShortcutsRepository.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/Interfaces/IShortcutsRepository.cs
@@ -1,10 +1,11 @@
 ﻿#nullable enable
 using System.Collections.Generic;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Models.Shortcuts;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Repositories.Interfaces;
 
-public interface IShortcutsRepository
+public interface IShortcutsRepository : IAsyncInitializable
 {
     IList<Shortcut> GetShortcuts();
     IEnumerable<Shortcut> GetPossibleShortcuts(string key);

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/Interfaces/IVariablesRepository.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/Interfaces/IVariablesRepository.cs
@@ -1,9 +1,10 @@
 ﻿using System.Collections.Generic;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.models;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Repositories.Interfaces;
 
-public interface IVariablesRepository
+public interface IVariablesRepository : IAsyncInitializable
 {
     public void AddVariable(string name, string value);
     public void RemoveVariable(string name);

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/ShortcutsRepository.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/ShortcutsRepository.cs
@@ -109,12 +109,13 @@ public class ShortcutsRepository : IShortcutsRepository
                          .ToList();
     }
 
-    public void GroupShortcuts(string groupKey, IEnumerable<string> shortcutKeys)
+    public void GroupShortcuts(string groupKey, bool groupLaunch, IEnumerable<string> shortcutKeys)
     {
         var group = new GroupShortcut
         {
             Key = groupKey,
-            Keys = shortcutKeys.ToList()
+            Keys = shortcutKeys.ToList(),
+            GroupLaunch = groupLaunch
         };
 
         _shortcuts.TryGetValue(groupKey, out var value);

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/ShortcutsRepository.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/ShortcutsRepository.cs
@@ -4,10 +4,10 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Models.Shortcuts;
 using Flow.Launcher.Plugin.ShortcutPlugin.Repositories.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
-using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 using FuzzySharp;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Repositories;

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/ShortcutsRepository.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/ShortcutsRepository.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Serialization;
 using Flow.Launcher.Plugin.ShortcutPlugin.Models.Shortcuts;
 using Flow.Launcher.Plugin.ShortcutPlugin.Repositories.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
+using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 using FuzzySharp;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Repositories;
@@ -14,14 +15,14 @@ namespace Flow.Launcher.Plugin.ShortcutPlugin.Repositories;
 public class ShortcutsRepository : IShortcutsRepository
 {
     private readonly ISettingsService _settingsService;
-    private readonly PluginInitContext _context;
+    private readonly IPluginManager _pluginManager;
 
     private Dictionary<string, List<Shortcut>> _shortcuts;
 
-    public ShortcutsRepository(ISettingsService settingsService, PluginInitContext context)
+    public ShortcutsRepository(ISettingsService settingsService, IPluginManager pluginManager)
     {
         _settingsService = settingsService;
-        _context = context;
+        _pluginManager = pluginManager;
 
         _shortcuts = ReadShortcuts(settingsService.GetSettingOrDefault(x => x.ShortcutsPath));
     }
@@ -163,12 +164,12 @@ public class ShortcutsRepository : IShortcutsRepository
             SaveShortcuts();
             ReloadShortcuts();
 
-            _context.API.ShowMsg("Shortcuts imported successfully");
+            _pluginManager.API.ShowMsg("Shortcuts imported successfully");
         }
         catch (Exception ex)
         {
-            _context.API.ShowMsg("Error while importing shortcuts");
-            _context.API.LogException(nameof(ShortcutsRepository), "Error importing shortcuts", ex);
+            _pluginManager.API.ShowMsg("Error while importing shortcuts");
+            _pluginManager.API.LogException(nameof(ShortcutsRepository), "Error importing shortcuts", ex);
         }
     }
 
@@ -176,7 +177,7 @@ public class ShortcutsRepository : IShortcutsRepository
     {
         if (!File.Exists(_settingsService.GetSettingOrDefault(x => x.ShortcutsPath)))
         {
-            _context.API.ShowMsg("No shortcuts to export");
+            _pluginManager.API.ShowMsg("No shortcuts to export");
             return;
         }
 
@@ -186,8 +187,8 @@ public class ShortcutsRepository : IShortcutsRepository
         }
         catch (Exception ex)
         {
-            _context.API.ShowMsg("Error while exporting shortcuts");
-            _context.API.LogException(nameof(ShortcutsRepository), "Error exporting shortcuts", ex);
+            _pluginManager.API.ShowMsg("Error while exporting shortcuts");
+            _pluginManager.API.LogException(nameof(ShortcutsRepository), "Error exporting shortcuts", ex);
         }
     }
 
@@ -211,8 +212,8 @@ public class ShortcutsRepository : IShortcutsRepository
         }
         catch (Exception e)
         {
-            _context.API.ShowMsg("Error while reading shortcuts. Please check the shortcuts config file.");
-            _context.API.LogException(nameof(ShortcutsRepository), "Error reading shortcuts", e);
+            _pluginManager.API.ShowMsg("Error while reading shortcuts. Please check the shortcuts config file.");
+            _pluginManager.API.LogException(nameof(ShortcutsRepository), "Error reading shortcuts", e);
 
             return new Dictionary<string, List<Shortcut>>();
         }

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/VariablesRepository.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/VariablesRepository.cs
@@ -15,15 +15,15 @@ public class VariablesRepository : IVariablesRepository
 {
     private readonly ISettingsService _settingsService;
 
-    private readonly PluginInitContext _context;
+    private readonly IPluginManager _pluginManager;
 
     private Dictionary<string, Variable> _variables;
 
 
-    public VariablesRepository(ISettingsService settingsService, PluginInitContext context)
+    public VariablesRepository(ISettingsService settingsService, IPluginManager pluginManager)
     {
         _settingsService = settingsService;
-        _context = context;
+        _pluginManager = pluginManager;
         _variables = ReadVariables(VariablesPath);
     }
 
@@ -98,12 +98,12 @@ public class VariablesRepository : IVariablesRepository
             SaveVariables();
             Reload();
 
-            _context.API.ShowMsg("Variables imported successfully");
+            _pluginManager.API.ShowMsg("Variables imported successfully");
         }
         catch (Exception ex)
         {
-            _context.API.ShowMsg("Error while importing variables");
-            _context.API.LogException(nameof(VariablesRepository), "Error importing variables", ex);
+            _pluginManager.API.ShowMsg("Error while importing variables");
+            _pluginManager.API.LogException(nameof(VariablesRepository), "Error importing variables", ex);
         }
     }
 
@@ -111,7 +111,7 @@ public class VariablesRepository : IVariablesRepository
     {
         if (!File.Exists(_settingsService.GetSettingOrDefault(x => x.VariablesPath)))
         {
-            _context.API.ShowMsg("No variables to export");
+            _pluginManager.API.ShowMsg("No variables to export");
             return;
         }
 
@@ -121,8 +121,8 @@ public class VariablesRepository : IVariablesRepository
         }
         catch (Exception ex)
         {
-            _context.API.ShowMsg("Error while exporting variables");
-            _context.API.LogException(nameof(VariablesRepository), "Error exporting variables", ex);
+            _pluginManager.API.ShowMsg("Error while exporting variables");
+            _pluginManager.API.LogException(nameof(VariablesRepository), "Error exporting variables", ex);
         }
     }
 

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/VariablesRepository.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Repositories/VariablesRepository.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.models;
 using Flow.Launcher.Plugin.ShortcutPlugin.Repositories.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
-using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 using FuzzySharp;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Repositories;

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Services/BackupService.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Services/BackupService.cs
@@ -1,10 +1,9 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Flow.Launcher.Plugin.ShortcutPlugin.Extensions;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper;
 using Flow.Launcher.Plugin.ShortcutPlugin.Repositories.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
-using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Services;
 
@@ -118,6 +117,6 @@ public class BackupService : IBackupService
         var noResult = ResultExtensions.Result("No", "Selecting this will cancel the operation",
             score: 1000);
 
-        return new List<Result> {question, yesResult, noResult};
+        return [question, yesResult, noResult];
     }
 }

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Services/CommandsService.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Services/CommandsService.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Flow.Launcher.Plugin.ShortcutPlugin.Models.Shortcuts;
 using Flow.Launcher.Plugin.ShortcutPlugin.Repositories.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
 
@@ -7,33 +6,15 @@ namespace Flow.Launcher.Plugin.ShortcutPlugin.Services;
 
 public class CommandsService : ICommandsService
 {
-    private readonly ISettingsService _settingsService;
-    private readonly IShortcutsService _shortcutsService;
-    private readonly IVariablesService _variablesService;
     private readonly ICommandsRepository _commandsRepository;
 
-    public CommandsService(
-        IShortcutsService shortcutsService,
-        ISettingsService settingsService,
-        IVariablesService variablesService,
-        ICommandsRepository commandsRepository
-    )
+    public CommandsService(ICommandsRepository commandsRepository)
     {
-        _shortcutsService = shortcutsService;
-        _settingsService = settingsService;
-        _variablesService = variablesService;
         _commandsRepository = commandsRepository;
     }
 
     public List<Result> ResolveCommand(List<string> arguments, Query query)
     {
         return _commandsRepository.ResolveCommand(arguments, query);
-    }
-
-    public void ReloadPluginData()
-    {
-        _settingsService.Reload();
-        _shortcutsService.Reload();
-        _variablesService.Reload();
     }
 }

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Services/Interfaces/ICommandsService.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Services/Interfaces/ICommandsService.cs
@@ -5,6 +5,4 @@ namespace Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
 public interface ICommandsService
 {
     List<Result> ResolveCommand(List<string> arguments, Query query);
-
-    void ReloadPluginData();
 }

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Services/SettingsService.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Services/SettingsService.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.IO;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.models;
 using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
-using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Services;
 

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Services/SettingsService.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Services/SettingsService.cs
@@ -8,15 +8,15 @@ namespace Flow.Launcher.Plugin.ShortcutPlugin.Services;
 
 public class SettingsService : ISettingsService
 {
-    private readonly PluginInitContext _context;
+    private readonly IPluginManager _pluginManager;
 
     private Settings _settings;
 
     private readonly Settings _defaultSettings;
 
-    public SettingsService(PluginInitContext context)
+    public SettingsService(IPluginManager pluginManager)
     {
-        _context = context;
+        _pluginManager = pluginManager;
         _defaultSettings = GetDefaultSettings();
 
         LoadSettings();
@@ -69,7 +69,7 @@ public class SettingsService : ISettingsService
     {
         var modified = false;
 
-        var shortcutPluginDirectory = _context.CurrentPluginMetadata.PluginDirectory;
+        var shortcutPluginDirectory = _pluginManager.Metadata.PluginDirectory;
         var pluginsDirectory = Directory.GetParent(shortcutPluginDirectory)?.Parent?.FullName;
 
         if (pluginsDirectory is null)
@@ -102,24 +102,24 @@ public class SettingsService : ISettingsService
 
         SaveSettings();
 
-        _context.API.ShowMsg("Settings paths have been migrated to the new location.",
+        _pluginManager.API.ShowMsg("Settings paths have been migrated to the new location.",
             "Settings have been migrated because you where using the default settings path. This should fix the issue when shortcuts disappear after updating the plugin.");
-        _context.API.ReloadAllPluginData();
+        _pluginManager.API.ReloadAllPluginData();
     }
 
     private void SaveSettings()
     {
-        _context.API.SaveSettingJsonStorage<Settings>();
+        _pluginManager.API.SaveSettingJsonStorage<Settings>();
     }
 
     private void LoadSettings()
     {
-        _settings = _context.API.LoadSettingJsonStorage<Settings>();
+        _settings = _pluginManager.API.LoadSettingJsonStorage<Settings>();
     }
 
     private Settings GetDefaultSettings()
     {
-        var pluginDirectory = _context.CurrentPluginMetadata.PluginDirectory;
+        var pluginDirectory = _pluginManager.Metadata.PluginDirectory;
         var parentDirectory = Directory.GetParent(pluginDirectory)?.Parent?.FullName;
 
         if (parentDirectory is null)

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Services/ShortcutsService.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Services/ShortcutsService.cs
@@ -17,17 +17,18 @@ public class ShortcutsService : IShortcutsService
     private readonly IShortcutsRepository _shortcutsRepository;
     private readonly IVariablesService _variablesService;
 
-    private readonly PluginInitContext _context;
+    private readonly IPluginManager _pluginManager;
 
     public ShortcutsService(
         IShortcutsRepository shortcutsRepository,
         IShortcutHandler shortcutHandler,
-        IVariablesService variablesService, PluginInitContext context)
+        IVariablesService variablesService,
+        IPluginManager pluginManager)
     {
         _shortcutsRepository = shortcutsRepository;
         _shortcutHandler = shortcutHandler;
         _variablesService = variablesService;
-        _context = context;
+        _pluginManager = pluginManager;
     }
 
     public List<Result> GetShortcuts(List<string> arguments)
@@ -77,10 +78,7 @@ public class ShortcutsService : IShortcutsService
                .Select(group => BuildShortcutResult(
                    shortcut: group,
                    arguments: [],
-                   action: () =>
-                   {
-                       _context.API.ChangeQuery($"{_context.CurrentPluginMetadata.ActionKeywords[0]} {group.Key}");
-                   },
+                   action: () => { _pluginManager.ChangeQueryWithAppendedKeyword(group.Key); },
                    hideAfterAction: false
                ))
                .ToList();
@@ -307,11 +305,9 @@ public class ShortcutsService : IShortcutsService
             title: title,
             subtitle: $"{groupShortcut} {joinedArguments}",
             titleHighlightData: highlightIndexes,
-            action: () =>
-            {
-                _context.API.ChangeQuery($"{_context.CurrentPluginMetadata.ActionKeywords[0]} {groupShortcut.Key}");
-            },
-            hideAfterAction: false
+            action: () => { _pluginManager.ChangeQueryWithAppendedKeyword(groupShortcut.Key); },
+            hideAfterAction: false,
+            autoCompleteText: _pluginManager.AppendActionKeyword(groupShortcut.Key)
         ));
 
         if (!expandGroups)

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Services/VariablesService.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Services/VariablesService.cs
@@ -2,9 +2,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using Flow.Launcher.Plugin.ShortcutPlugin.Extensions;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Repositories.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
-using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 using Microsoft.Win32;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.Services;

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Services/VariablesService.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Services/VariablesService.cs
@@ -13,12 +13,12 @@ public class VariablesService : IVariablesService
 {
     private readonly IVariablesRepository _variablesRepository;
 
-    private readonly PluginInitContext _context;
+    private readonly IPluginManager _pluginManager;
 
-    public VariablesService(IVariablesRepository variablesRepository, PluginInitContext context)
+    public VariablesService(IVariablesRepository variablesRepository, IPluginManager pluginManager)
     {
         _variablesRepository = variablesRepository;
-        _context = context;
+        _pluginManager = pluginManager;
     }
 
     public List<Result> GetVariables()
@@ -46,7 +46,7 @@ public class VariablesService : IVariablesService
                     IcoPath = Icons.Logo,
                     Action = _ =>
                     {
-                        _context.API.CopyToClipboard($"Variable: {variable.Name} value: {variable.Value}");
+                        _pluginManager.API.CopyToClipboard($"Variable: {variable.Name} value: {variable.Value}");
                         return true;
                     },
                     AutoCompleteText = $"Variable: {variable.Name} value: {variable.Value}"

--- a/Flow.Launcher.Plugin.ShortcutPlugin/ShortcutPlugin.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/ShortcutPlugin.cs
@@ -1,9 +1,10 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Controls;
 using Flow.Launcher.Plugin.ShortcutPlugin.DI;
 using Flow.Launcher.Plugin.ShortcutPlugin.Extensions;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
-using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 using Flow.Launcher.Plugin.ShortcutPlugin.ViewModels;
 using Flow.Launcher.Plugin.ShortcutPlugin.Views;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,6 +23,7 @@ public class ShortcutPlugin : IPlugin, ISettingProvider, IReloadable, IContextMe
     private ContextMenu _contextMenu;
 
     private IPluginManager _pluginManager;
+    private IReloadable _reloadable;
 
 
     public void Init(PluginInitContext context)
@@ -33,8 +35,12 @@ public class ShortcutPlugin : IPlugin, ISettingProvider, IReloadable, IContextMe
 
         _commandsService = serviceProvider.GetService<ICommandsService>();
         _pluginManager = serviceProvider.GetService<IPluginManager>();
+
         _contextMenu = serviceProvider.GetService<ContextMenu>();
         _settingsViewModel = serviceProvider.GetService<SettingsViewModel>();
+
+        _reloadable = serviceProvider.GetService<IReloadable>();
+        _pluginManager.SetReloadable(_reloadable);
 
         ServiceProvider = serviceProvider;
     }
@@ -51,8 +57,7 @@ public class ShortcutPlugin : IPlugin, ISettingProvider, IReloadable, IContextMe
 
     public void ReloadData()
     {
-        _pluginManager.ClearLastQuery();
-        _commandsService.ReloadPluginData();
+        _pluginManager.ReloadPluginData();
     }
 
     public List<Result> LoadContextMenus(Result selectedResult)

--- a/Flow.Launcher.Plugin.ShortcutPlugin/ShortcutPlugin.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/ShortcutPlugin.cs
@@ -3,6 +3,7 @@ using System.Windows.Controls;
 using Flow.Launcher.Plugin.ShortcutPlugin.DI;
 using Flow.Launcher.Plugin.ShortcutPlugin.Extensions;
 using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
+using Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 using Flow.Launcher.Plugin.ShortcutPlugin.ViewModels;
 using Flow.Launcher.Plugin.ShortcutPlugin.Views;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,6 +21,9 @@ public class ShortcutPlugin : IPlugin, ISettingProvider, IReloadable, IContextMe
     private SettingsViewModel _settingsViewModel;
     private ContextMenu _contextMenu;
 
+    private IPluginManager _pluginManager;
+
+
     public void Init(PluginInitContext context)
     {
         var serviceProvider = new ServiceCollection()
@@ -28,6 +32,7 @@ public class ShortcutPlugin : IPlugin, ISettingProvider, IReloadable, IContextMe
                               .BuildServiceProvider();
 
         _commandsService = serviceProvider.GetService<ICommandsService>();
+        _pluginManager = serviceProvider.GetService<IPluginManager>();
         _contextMenu = serviceProvider.GetService<ContextMenu>();
         _settingsViewModel = serviceProvider.GetService<SettingsViewModel>();
 
@@ -36,6 +41,8 @@ public class ShortcutPlugin : IPlugin, ISettingProvider, IReloadable, IContextMe
 
     public List<Result> Query(Query query)
     {
+        _pluginManager.SetLastQuery(query);
+
         var args = CommandLineExtensions.SplitArguments(query.Search);
         var results = _commandsService.ResolveCommand(args, query);
 
@@ -44,6 +51,7 @@ public class ShortcutPlugin : IPlugin, ISettingProvider, IReloadable, IContextMe
 
     public void ReloadData()
     {
+        _pluginManager.ClearLastQuery();
         _commandsService.ReloadPluginData();
     }
 

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Utilities/IPluginManager.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Utilities/IPluginManager.cs
@@ -1,0 +1,54 @@
+namespace Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
+
+public interface IPluginManager
+{
+    /// <summary>
+    /// The context of the plugin
+    /// </summary>
+    PluginInitContext Context { get; }
+
+    /// <summary>
+    /// The public API of the plugin
+    /// </summary>
+    IPublicAPI API { get; }
+
+    /// <summary>
+    /// The metadata of the plugin
+    /// </summary>
+    PluginMetadata Metadata { get; }
+
+    /// <summary>
+    /// The last query that was sent to the plugin
+    /// </summary>
+    Query LastQuery { get; }
+
+    /// <summary>
+    /// Set the last query that was sent to the plugin
+    /// </summary>
+    /// <param name="query">The query to set</param>
+    void SetLastQuery(Query query);
+
+    /// <summary>
+    /// Clear the last query
+    /// </summary>
+    void ClearLastQuery();
+
+    /// <summary>
+    /// Get the action keyword from the last query or the first action keyword from the plugin metadata
+    /// </summary>
+    /// <returns></returns>
+    string GetActionKeyword();
+
+    /// <summary>
+    /// Append the action keyword in front of the text
+    /// </summary>
+    /// <param name="text">The text to append</param>
+    /// <returns>The text with the action keyword appended</returns>
+    string AppendActionKeyword(string text);
+
+    /// <summary>
+    /// Change the query with the appended action keyword in front of the text
+    /// </summary>
+    /// <param name="text">The text to append</param>
+    void ChangeQueryWithAppendedKeyword(string text);
+}

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Utilities/PluginManager.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Utilities/PluginManager.cs
@@ -1,0 +1,52 @@
+namespace Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
+
+public class PluginManager : IPluginManager
+{
+    public PluginInitContext Context { get; }
+
+    public IPublicAPI API => Context.API;
+
+    public PluginMetadata Metadata => Context.CurrentPluginMetadata;
+
+    public Query LastQuery { get; private set; }
+
+
+    public PluginManager(PluginInitContext context)
+    {
+        Context = context;
+        LastQuery = new Query();
+    }
+
+    public void SetLastQuery(Query query)
+    {
+        LastQuery = query;
+    }
+
+    public void ClearLastQuery()
+    {
+        LastQuery = new Query();
+    }
+
+    public string GetActionKeyword()
+    {
+        return LastQuery == null
+            ? Context.CurrentPluginMetadata.ActionKeywords[0]
+            : LastQuery.ActionKeyword;
+    }
+
+    public string AppendActionKeyword(string text)
+    {
+        var actionKeyword = GetActionKeyword();
+
+        return string.IsNullOrWhiteSpace(actionKeyword)
+            ? text
+            : $"{actionKeyword} {text}";
+    }
+
+    public void ChangeQueryWithAppendedKeyword(string text)
+    {
+        var query = AppendActionKeyword(text);
+
+        API.ChangeQuery(query);
+    }
+}

--- a/Flow.Launcher.Plugin.ShortcutPlugin/Utilities/ShortcutHandler.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/Utilities/ShortcutHandler.cs
@@ -11,18 +11,18 @@ namespace Flow.Launcher.Plugin.ShortcutPlugin.Utilities;
 
 public class ShortcutHandler : IShortcutHandler
 {
-    private readonly PluginInitContext _context;
+    private readonly IPluginManager _pluginManager;
     private readonly IShortcutsRepository _shortcutsRepository;
     private readonly IVariablesService _variablesService;
 
     public ShortcutHandler(
         IVariablesService variablesService,
-        PluginInitContext context,
+        IPluginManager pluginManager,
         IShortcutsRepository shortcutsRepository
     )
     {
         _variablesService = variablesService;
-        _context = context;
+        _pluginManager = pluginManager;
         _shortcutsRepository = shortcutsRepository;
     }
 
@@ -70,7 +70,7 @@ public class ShortcutHandler : IShortcutHandler
             }
             default:
             {
-                _context.API.LogInfo(nameof(ShortcutHandler), "Shortcut type not supported");
+                _pluginManager.API.LogInfo(nameof(ShortcutHandler), "Shortcut type not supported");
                 break;
             }
         }
@@ -124,7 +124,7 @@ public class ShortcutHandler : IShortcutHandler
             }
             default:
             {
-                _context.API.LogInfo(nameof(ShortcutHandler), "Shell type not supported");
+                _pluginManager.API.LogInfo(nameof(ShortcutHandler), "Shell type not supported");
                 break;
             }
         }
@@ -148,7 +148,7 @@ public class ShortcutHandler : IShortcutHandler
 
         if (enumerable.Any(shortcut => IsRecursiveGroupShortcut(shortcut, groupKey)))
         {
-            _context.API.ShowMsg(Resources.Error_recursive_group_shortcut,
+            _pluginManager.API.ShowMsg(Resources.Error_recursive_group_shortcut,
                 "Remove the recursive group shortcut in shortcuts list of the group shortcut");
             return;
         }
@@ -176,7 +176,7 @@ public class ShortcutHandler : IShortcutHandler
 
         if (keysList.Contains(groupKey))
         {
-            _context.API.ShowMsg(Resources.Error_recursive_group_shortcut,
+            _pluginManager.API.ShowMsg(Resources.Error_recursive_group_shortcut,
                 "Remove the recursive group shortcut in keys list of the group shortcut");
             return;
         }
@@ -200,7 +200,7 @@ public class ShortcutHandler : IShortcutHandler
     }
 
     // ReSharper disable once UnusedMember.Local
-    /*private List<Result> ExecutePluginShortcut(PluginInitContext context, PluginShortcut shortcut)
+    /*private List<Result> ExecutePluginShortcut(IPluginManager pluginManager, PluginShortcut shortcut)
     {
         return ResultExtensions.SingleResult(
             "Executing plugin shortcut",
@@ -210,7 +210,7 @@ public class ShortcutHandler : IShortcutHandler
 
         void Action()
         {
-            var plugins = context.API.GetAllPlugins();
+            var plugins = pluginManager.API.GetAllPlugins();
             var plugin = plugins.First(x => x.Metadata.Name.Equals(shortcut.PluginName));
 
             var query = QueryBuilder.Build(shortcut.RawQuery);

--- a/Flow.Launcher.Plugin.ShortcutPlugin/ViewModels/SettingsViewModel.cs
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/ViewModels/SettingsViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Flow.Launcher.Plugin.ShortcutPlugin.Helper.Interfaces;
 using Flow.Launcher.Plugin.ShortcutPlugin.Services.Interfaces;
 
 namespace Flow.Launcher.Plugin.ShortcutPlugin.ViewModels;
@@ -8,17 +9,17 @@ public partial class SettingsViewModel : ObservableObject
 {
     private readonly ISettingsService _settingsService;
 
-    private readonly ICommandsService _commandsService;
+    private readonly IPluginManager _pluginManager;
 
     [ObservableProperty] private string _shortcutsPath;
 
     [ObservableProperty] private string _variablesPath;
 
 
-    public SettingsViewModel(ICommandsService commandsService, ISettingsService settingsService)
+    public SettingsViewModel(IPluginManager pluginManager, ISettingsService settingsService)
     {
-        _commandsService = commandsService;
         _settingsService = settingsService;
+        _pluginManager = pluginManager;
 
         ShortcutsPath = _settingsService.GetSettingOrDefault(x => x.ShortcutsPath);
         VariablesPath = _settingsService.GetSettingOrDefault(x => x.VariablesPath);
@@ -62,7 +63,7 @@ public partial class SettingsViewModel : ObservableObject
 
         if (isModified)
         {
-            _commandsService.ReloadPluginData();
+            _pluginManager.ReloadPluginData();
         }
     }
 
@@ -74,7 +75,7 @@ public partial class SettingsViewModel : ObservableObject
         ShortcutsPath = _settingsService.GetSettingOrDefault(x => x.ShortcutsPath);
         VariablesPath = _settingsService.GetSettingOrDefault(x => x.VariablesPath);
 
-        _commandsService.ReloadPluginData();
+        _pluginManager.ReloadPluginData();
     }
 
     [RelayCommand]

--- a/Flow.Launcher.Plugin.ShortcutPlugin/plugin.json
+++ b/Flow.Launcher.Plugin.ShortcutPlugin/plugin.json
@@ -3,11 +3,11 @@
   "Name": "Shortcuts",
   "Description": "Open user defined shortcut quickly from Flow Launcher",
   "Author": "Mantelis",
-  "Version": "1.2.0",
+  "Version": "1.2.1",
   "Language": "csharp",
   "ActionKeyword": "q",
   "Website": "https://github.com/mantasjasikenas/flow-launcher-shortcuts-plugin",
-  "UrlDownload":"https://github.com/mantasjasikenas/flow-launcher-shortcuts-plugin/releases/download/v1.2.0/Flow.Launcher.Plugin.ShortcutPlugin.zip",
+  "UrlDownload":"https://github.com/mantasjasikenas/flow-launcher-shortcuts-plugin/releases/download/v1.2.1/Flow.Launcher.Plugin.ShortcutPlugin.zip",
   "UrlSourceCode": "https://github.com/mantasjasikenas/flow-launcher-shortcuts-plugin/tree/master",
   "IcoPath": "images\\icon.png",
   "ExecuteFileName": "Flow.Launcher.Plugin.ShortcutPlugin.dll"


### PR DESCRIPTION
- Do not autocomplete the result when Enter is pressed if the argument is not a literal type.
- Added a `LaunchGroup` field to group shortcuts. If set to `true`, you can launch all shortcuts in the group
  simultaneously. Otherwise, you can only launch a single shortcut from the group simultaneously.
- When the group shortcut name (key) is not fully typed, selecting the group shortcut from the list will replace the
  query with the group shortcut name.
- Icons folder support: If a directory type shortcut with the key `icons` is added, the plugin will search for icons for
  shortcuts based on the shortcut key matching the icon file name. The icon file name should be the same as the
  shortcut. Supported file extensions: `.png`, `.jpg`, `.jpeg`, `.ico`.